### PR TITLE
[BE] feat: 주문/주문 상세 내역 조회 페이지네이션 기능 구현

### DIFF
--- a/server/src/main/java/com/frame2/server/core/order/api/OrderApi.java
+++ b/server/src/main/java/com/frame2/server/core/order/api/OrderApi.java
@@ -4,13 +4,14 @@ import com.frame2.server.core.order.application.OrderService;
 import com.frame2.server.core.order.payload.request.OrderCreateRequest;
 import com.frame2.server.core.order.payload.response.OrderDetailResponse;
 import com.frame2.server.core.order.payload.response.OrderResponse;
-import com.frame2.server.core.support.annotations.MemberOnly;
 import com.frame2.server.core.support.response.IdResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PagedModel;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 
 @RestController
@@ -22,7 +23,7 @@ public class OrderApi implements OrderApiSpec{
     
     // 주문 생성
     @Override
-    @MemberOnly
+    //@MemberOnly
     @PostMapping
     public IdResponse createOrder(@RequestBody @Valid OrderCreateRequest request) {
         return orderServiceImpl.createOrder(request);
@@ -30,7 +31,7 @@ public class OrderApi implements OrderApiSpec{
     
     // 주문 단건 조회
     @Override
-    @MemberOnly
+    //@MemberOnly
     @GetMapping("/{orderId}")
     public OrderResponse getOrder(@PathVariable Long orderId) {
         return orderServiceImpl.getOrder(orderId);
@@ -38,15 +39,18 @@ public class OrderApi implements OrderApiSpec{
     
     // 주문 전체 조회
     @Override
-    @MemberOnly
+    //@MemberOnly
     @GetMapping("/members/{memberId}")
-    public List<OrderResponse> getOrders(@PathVariable Long memberId) {
-        return orderServiceImpl.getOrders(memberId);
+    public PagedModel<OrderResponse> getOrders(@PathVariable Long memberId,
+                                               @RequestParam(name = "page", defaultValue = "1") int page,
+                                               @RequestParam(name = "size", defaultValue = "15") int pageSize) {
+        Pageable pageable = PageRequest.of(page - 1, pageSize, Sort.by(Sort.Direction.DESC, "id"));
+        return orderServiceImpl.getOrders(memberId, pageable);
     }
     
     // 주문 상세 단건 조회
     @Override
-    @MemberOnly
+    //@MemberOnly
     @GetMapping("/details/{orderDetailId}")
     public OrderDetailResponse getOderDetail(@PathVariable Long orderDetailId){
         return orderServiceImpl.getOderDetail(orderDetailId);
@@ -54,9 +58,13 @@ public class OrderApi implements OrderApiSpec{
     
     // 주문 상세 전체 조회
     @Override
-    @MemberOnly
+    //@MemberOnly
     @GetMapping("/{orderId}/details")
-    public List<OrderDetailResponse> getOrderDetails(@PathVariable Long orderId){
-        return orderServiceImpl.getOrderDetails(orderId);
+    public PagedModel<OrderDetailResponse> getOrderDetails(
+            @PathVariable Long orderId,
+            @RequestParam(name = "page", defaultValue = "1") int page,
+            @RequestParam(name = "size", defaultValue = "15") int pageSize) {
+        Pageable pageable = PageRequest.of(page - 1, pageSize);
+        return orderServiceImpl.getOrderDetails(orderId, pageable);
     }
 }

--- a/server/src/main/java/com/frame2/server/core/order/api/OrderApi.java
+++ b/server/src/main/java/com/frame2/server/core/order/api/OrderApi.java
@@ -4,6 +4,7 @@ import com.frame2.server.core.order.application.OrderService;
 import com.frame2.server.core.order.payload.request.OrderCreateRequest;
 import com.frame2.server.core.order.payload.response.OrderDetailResponse;
 import com.frame2.server.core.order.payload.response.OrderResponse;
+import com.frame2.server.core.support.annotations.MemberOnly;
 import com.frame2.server.core.support.response.IdResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +24,7 @@ public class OrderApi implements OrderApiSpec{
     
     // 주문 생성
     @Override
-    //@MemberOnly
+    @MemberOnly
     @PostMapping
     public IdResponse createOrder(@RequestBody @Valid OrderCreateRequest request) {
         return orderServiceImpl.createOrder(request);
@@ -31,7 +32,7 @@ public class OrderApi implements OrderApiSpec{
     
     // 주문 단건 조회
     @Override
-    //@MemberOnly
+    @MemberOnly
     @GetMapping("/{orderId}")
     public OrderResponse getOrder(@PathVariable Long orderId) {
         return orderServiceImpl.getOrder(orderId);
@@ -39,7 +40,7 @@ public class OrderApi implements OrderApiSpec{
     
     // 주문 전체 조회
     @Override
-    //@MemberOnly
+    @MemberOnly
     @GetMapping("/members/{memberId}")
     public PagedModel<OrderResponse> getOrders(@PathVariable Long memberId,
                                                @RequestParam(name = "page", defaultValue = "1") int page,
@@ -50,7 +51,7 @@ public class OrderApi implements OrderApiSpec{
     
     // 주문 상세 단건 조회
     @Override
-    //@MemberOnly
+    @MemberOnly
     @GetMapping("/details/{orderDetailId}")
     public OrderDetailResponse getOderDetail(@PathVariable Long orderDetailId){
         return orderServiceImpl.getOderDetail(orderDetailId);
@@ -58,7 +59,7 @@ public class OrderApi implements OrderApiSpec{
     
     // 주문 상세 전체 조회
     @Override
-    //@MemberOnly
+    @MemberOnly
     @GetMapping("/{orderId}/details")
     public PagedModel<OrderDetailResponse> getOrderDetails(
             @PathVariable Long orderId,

--- a/server/src/main/java/com/frame2/server/core/order/api/OrderApiSpec.java
+++ b/server/src/main/java/com/frame2/server/core/order/api/OrderApiSpec.java
@@ -5,6 +5,7 @@ import com.frame2.server.core.order.payload.response.OrderDetailResponse;
 import com.frame2.server.core.order.payload.response.OrderResponse;
 import com.frame2.server.core.support.response.IdResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.web.PagedModel;
 
 import java.util.List;
 
@@ -13,7 +14,7 @@ public interface OrderApiSpec {
 
     public IdResponse createOrder(OrderCreateRequest request);
     public OrderResponse getOrder(Long orderId);
-    public List<OrderResponse> getOrders(Long memberId);
+    public PagedModel<OrderResponse> getOrders(Long memberId, int page, int pageSize);
     public OrderDetailResponse getOderDetail(Long orderDetailId);
-    public List<OrderDetailResponse> getOrderDetails(Long orderId);
+    public PagedModel<OrderDetailResponse> getOrderDetails(Long orderId, int page, int pageSize);
 }

--- a/server/src/main/java/com/frame2/server/core/order/application/OrderService.java
+++ b/server/src/main/java/com/frame2/server/core/order/application/OrderService.java
@@ -15,5 +15,5 @@ public interface OrderService {
     public OrderResponse getOrder(Long orderId);
     public PagedModel<OrderResponse> getOrders(Long memberId, Pageable pageable);
     public OrderDetailResponse getOderDetail(Long orderDetailId);
-    public PagedModel<OrderDetailResponse> getOrderDetails(Long orderId, Pageable pageable);
+    public List<OrderDetailResponse> getOrderDetails(Long orderId);
 }

--- a/server/src/main/java/com/frame2/server/core/order/application/OrderService.java
+++ b/server/src/main/java/com/frame2/server/core/order/application/OrderService.java
@@ -4,6 +4,8 @@ import com.frame2.server.core.order.payload.request.OrderCreateRequest;
 import com.frame2.server.core.order.payload.response.OrderDetailResponse;
 import com.frame2.server.core.order.payload.response.OrderResponse;
 import com.frame2.server.core.support.response.IdResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedModel;
 
 import java.util.List;
 
@@ -11,7 +13,7 @@ public interface OrderService {
 
     public IdResponse createOrder(OrderCreateRequest request);
     public OrderResponse getOrder(Long orderId);
-    public List<OrderResponse> getOrders(Long memberId);
+    public PagedModel<OrderResponse> getOrders(Long memberId, Pageable pageable);
     public OrderDetailResponse getOderDetail(Long orderDetailId);
-    public List<OrderDetailResponse> getOrderDetails(Long orderId);
+    public PagedModel<OrderDetailResponse> getOrderDetails(Long orderId, Pageable pageable);
 }

--- a/server/src/main/java/com/frame2/server/core/order/application/OrderServiceImpl.java
+++ b/server/src/main/java/com/frame2/server/core/order/application/OrderServiceImpl.java
@@ -12,6 +12,9 @@ import com.frame2.server.core.product.infrastructure.SaleProductRepository;
 import com.frame2.server.core.support.response.IdResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedModel;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -79,13 +82,12 @@ public class OrderServiceImpl implements OrderService {
         return OrderResponse.from(order);
     }
 
-    // TODO : 페이징 처리
     // 주문 내역 전체조회 - 멤버id로 전체 조회
     @Override
-    public List<OrderResponse> getOrders(Long memberId) {
-        return orderRepository.findAllByMemberId(memberId).stream()
-                .map(OrderResponse::from)
-                .toList();
+    public PagedModel<OrderResponse> getOrders(Long memberId, Pageable pageable) {
+        Page<Order> orders = orderRepository.findAllByMemberId(memberId, pageable);
+        Page<OrderResponse> orderResponses = orders.map(OrderResponse::from);
+        return new PagedModel<>(orderResponses);
     }
 
     // 주문 상세 내역 단건 조회 - 주문상세id로 단건 조회
@@ -95,12 +97,11 @@ public class OrderServiceImpl implements OrderService {
         return OrderDetailResponse.from(orderDetail);
     }
 
-    // TODO : 페이징 처리
     // 주문 상세 내역 전체조회 - 주문id로 주문 상세 내역 전체조회
     @Override
-    public List<OrderDetailResponse> getOrderDetails(Long orderId) {
-        return orderDetailRepository.findAllByOrderId(orderId).stream()
-                .map(OrderDetailResponse::from)
-                .toList();
+    public PagedModel<OrderDetailResponse> getOrderDetails(Long orderId, Pageable pageable) {
+        Page<OrderDetail> orderDetails = orderDetailRepository.findAllByOrderId(orderId, pageable);
+        Page<OrderDetailResponse> orderDetailResponses = orderDetails.map(OrderDetailResponse::from);
+        return new PagedModel<>(orderDetailResponses);
     }
 }

--- a/server/src/main/java/com/frame2/server/core/order/application/OrderServiceImpl.java
+++ b/server/src/main/java/com/frame2/server/core/order/application/OrderServiceImpl.java
@@ -85,9 +85,8 @@ public class OrderServiceImpl implements OrderService {
     // 주문 내역 전체조회 - 멤버id로 전체 조회
     @Override
     public PagedModel<OrderResponse> getOrders(Long memberId, Pageable pageable) {
-        Page<Order> orders = orderRepository.findAllByMemberId(memberId, pageable);
-        Page<OrderResponse> orderResponses = orders.map(OrderResponse::from);
-        return new PagedModel<>(orderResponses);
+        return new PagedModel<>(orderRepository.findAllByMemberId(memberId, pageable)
+                .map(OrderResponse::from));
     }
 
     // 주문 상세 내역 단건 조회 - 주문상세id로 단건 조회
@@ -99,9 +98,9 @@ public class OrderServiceImpl implements OrderService {
 
     // 주문 상세 내역 전체조회 - 주문id로 주문 상세 내역 전체조회
     @Override
-    public PagedModel<OrderDetailResponse> getOrderDetails(Long orderId, Pageable pageable) {
-        Page<OrderDetail> orderDetails = orderDetailRepository.findAllByOrderId(orderId, pageable);
-        Page<OrderDetailResponse> orderDetailResponses = orderDetails.map(OrderDetailResponse::from);
-        return new PagedModel<>(orderDetailResponses);
+    public List<OrderDetailResponse> getOrderDetails(Long orderId) {
+        return orderDetailRepository.findAllByOrderId(orderId).stream()
+                .map(OrderDetailResponse::from)
+                .toList();
     }
 }

--- a/server/src/main/java/com/frame2/server/core/order/domain/Order.java
+++ b/server/src/main/java/com/frame2/server/core/order/domain/Order.java
@@ -67,11 +67,11 @@ public class Order extends BaseEntity {
 
     // 대표상품명 업데이트
     public void updateProductName() {
-        if(orderDetails.size() == 1 ) {
-            this.mainProductName = orderDetails.get(0).getSaleProduct().getProduct().getName();
+        String mainProductName = orderDetails.getFirst().getSaleProduct().getName();
+        if(orderDetails.size() == 1){
+            this.mainProductName = mainProductName;
         } else {
-            String firstProductName = orderDetails.get(0).getSaleProduct().getProduct().getName();
-            this.mainProductName = firstProductName + " 외 " + (orderDetails.size() - 1) +"건";
+            this.mainProductName = mainProductName + " 외 " + (orderDetails.size() - 1)+"건";
         }
     }
     

--- a/server/src/main/java/com/frame2/server/core/order/domain/Order.java
+++ b/server/src/main/java/com/frame2/server/core/order/domain/Order.java
@@ -57,7 +57,7 @@ public class Order extends BaseEntity {
         this.recipientAddress1 = recipientAddress1;
         this.recipientAddress2 = recipientAddress2;
         this.deliveryRequest = deliveryRequest;
-        this.orderStatus = OrderStatus.ORDER_RECIEVED;
+        this.orderStatus = OrderStatus.ORDER_RECEIVED;
     }
 
     // 주문에 주문 상세 추가

--- a/server/src/main/java/com/frame2/server/core/order/domain/OrderStatus.java
+++ b/server/src/main/java/com/frame2/server/core/order/domain/OrderStatus.java
@@ -2,9 +2,8 @@ package com.frame2.server.core.order.domain;
 
 public enum OrderStatus {
 
-    ORDER_RECIEVED,         // 주문접수
+    ORDER_RECEIVED,         // 주문접수
     ORDER_COMPLETED,        // 주문완료
     ORDER_CANCELED,         // 주문취소
     PURCHASED_CONFIRMED;    // 구매확정
-
 }

--- a/server/src/main/java/com/frame2/server/core/order/infrastructure/OrderDetailRepository.java
+++ b/server/src/main/java/com/frame2/server/core/order/infrastructure/OrderDetailRepository.java
@@ -3,7 +3,8 @@ package com.frame2.server.core.order.infrastructure;
 import com.frame2.server.core.order.domain.OrderDetail;
 import com.frame2.server.core.support.exception.DomainException;
 import com.frame2.server.core.support.exception.ExceptionType;
-import org.springframework.boot.web.embedded.netty.NettyWebServer;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,5 +20,5 @@ public interface OrderDetailRepository extends JpaRepository<OrderDetail, Long> 
     }
 
     @Query("SELECT od FROM OrderDetail od WHERE od.order.id = :orderId")
-    List<OrderDetail> findAllByOrderId(@Param("orderId") Long orderId);
+    Page<OrderDetail> findAllByOrderId(@Param("orderId") Long orderId, Pageable pageable);
 }

--- a/server/src/main/java/com/frame2/server/core/order/infrastructure/OrderDetailRepository.java
+++ b/server/src/main/java/com/frame2/server/core/order/infrastructure/OrderDetailRepository.java
@@ -20,5 +20,5 @@ public interface OrderDetailRepository extends JpaRepository<OrderDetail, Long> 
     }
 
     @Query("SELECT od FROM OrderDetail od WHERE od.order.id = :orderId")
-    Page<OrderDetail> findAllByOrderId(@Param("orderId") Long orderId, Pageable pageable);
+    List<OrderDetail> findAllByOrderId(@Param("orderId") Long orderId);
 }

--- a/server/src/main/java/com/frame2/server/core/order/infrastructure/OrderRepository.java
+++ b/server/src/main/java/com/frame2/server/core/order/infrastructure/OrderRepository.java
@@ -3,10 +3,11 @@ package com.frame2.server.core.order.infrastructure;
 import com.frame2.server.core.order.domain.Order;
 import com.frame2.server.core.support.exception.DomainException;
 import com.frame2.server.core.support.exception.ExceptionType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long> {
@@ -15,5 +16,5 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
         return findById(id).orElseThrow(() -> new DomainException(ExceptionType.ORDER_NOT_FOUND));
     }
 
-    List<Order> findAllByMemberId(Long memberId);
+    Page<Order> findAllByMemberId(Long memberId, Pageable pageable);
 }


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #73 

---

### 🚀 어떤 기능을 구현했나요 ?
- [x] 멤버 id로 주문 내역을 전체 조회하는 경우 페이지네이션 처리
  - [x]  최근 주문 순으로 조회하기 위해 내림차순 정렬 적용  
- [x] ~~주문id로 주문 상세 내역을 전체 조회하는 경우 페이지네이션 처리~~

### 🔥 어떻게 해결했나요 ?
- `PagedModel` 사용
  -  `Page<T>`인터페이스의 `map()` 메서드 사용 : Page의 각 요소를 변환해 새로운 타입의 `Page`객체를 반환 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말

