### PR TITLE
[BE] feat: 주문 생성 시 재고 수량 감소 기능 구현

### DIFF
--- a/server/src/main/java/com/frame2/server/core/order/api/OrderApi.java
+++ b/server/src/main/java/com/frame2/server/core/order/api/OrderApi.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PagedModel;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 
 @RestController
 @RequiredArgsConstructor
@@ -61,11 +63,7 @@ public class OrderApi implements OrderApiSpec{
     @Override
     @MemberOnly
     @GetMapping("/{orderId}/details")
-    public PagedModel<OrderDetailResponse> getOrderDetails(
-            @PathVariable Long orderId,
-            @RequestParam(name = "page", defaultValue = "1") int page,
-            @RequestParam(name = "size", defaultValue = "15") int pageSize) {
-        Pageable pageable = PageRequest.of(page - 1, pageSize);
-        return orderServiceImpl.getOrderDetails(orderId, pageable);
+    public List<OrderDetailResponse> getOrderDetails(@PathVariable Long orderId) {
+        return orderServiceImpl.getOrderDetails(orderId);
     }
 }

--- a/server/src/main/java/com/frame2/server/core/order/api/OrderApiSpec.java
+++ b/server/src/main/java/com/frame2/server/core/order/api/OrderApiSpec.java
@@ -16,5 +16,5 @@ public interface OrderApiSpec {
     public OrderResponse getOrder(Long orderId);
     public PagedModel<OrderResponse> getOrders(Long memberId, int page, int pageSize);
     public OrderDetailResponse getOderDetail(Long orderDetailId);
-    public PagedModel<OrderDetailResponse> getOrderDetails(Long orderId, int page, int pageSize);
+    public List<OrderDetailResponse> getOrderDetails(Long orderId);
 }

--- a/server/src/main/java/com/frame2/server/core/order/application/OrderServiceImpl.java
+++ b/server/src/main/java/com/frame2/server/core/order/application/OrderServiceImpl.java
@@ -8,7 +8,10 @@ import com.frame2.server.core.order.payload.request.OrderCreateRequest;
 import com.frame2.server.core.order.payload.response.OrderDetailResponse;
 import com.frame2.server.core.order.payload.response.OrderResponse;
 import com.frame2.server.core.product.domain.SaleProduct;
+import com.frame2.server.core.product.domain.Stock;
 import com.frame2.server.core.product.infrastructure.SaleProductRepository;
+import com.frame2.server.core.support.exception.DomainException;
+import com.frame2.server.core.support.exception.ExceptionType;
 import com.frame2.server.core.support.response.IdResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +33,12 @@ public class OrderServiceImpl implements OrderService {
     private final SaleProductRepository saleProductRepository;
 
     public IdResponse createOrder(OrderCreateRequest request) {
+        // 요청에 포함된 판매상품의 재고 검증 - 재고 부족 시 Exception발생
+        request.orderDetails().forEach(orderDetail -> {
+            saleProductRepository.findOne(orderDetail.saleProductId())
+                    .getStock().validateQuantity(orderDetail.quantity());
+        });
+
         // 주문 생성
         Order order = request.toEntity();
         orderRepository.save(order);
@@ -43,10 +52,9 @@ public class OrderServiceImpl implements OrderService {
         // 판매상품 id 리스트로 판매상품을 리스트로 받아옴
         List<SaleProduct> saleProductList = saleProductRepository.findAllById(saleProductIdList);
 
-        // TODO: Exception 정의 필요
         // 주문 요청의 판매상품 개수와 레포지토리에서 가져온 판매상품 개수 비교
         if(saleProductIdList.size() != saleProductList.size()) {
-            throw new IllegalArgumentException("판매상품 중 일부가 존재하지 않습니다.");
+            throw new DomainException(ExceptionType.SALE_PRODUCT_MISMATCH);
         }
 
         // <ID, SaleProduct>를 미리 매핑
@@ -57,6 +65,10 @@ public class OrderServiceImpl implements OrderService {
                 .map(orderDetail -> {
                     // 주문 상세와 판매상품을 매핑
                     SaleProduct saleProduct = saleProductMap.get(orderDetail.saleProductId());
+                    
+                    // 판매상품의 재고 차감
+                    Stock stock = saleProduct.getStock();
+                    stock.reduceQuantity(orderDetail.quantity());
 
                     // 주문 상세 생성
                     return OrderDetail.builder()

--- a/server/src/main/java/com/frame2/server/core/product/domain/Stock.java
+++ b/server/src/main/java/com/frame2/server/core/product/domain/Stock.java
@@ -1,6 +1,8 @@
 package com.frame2.server.core.product.domain;
 
 import com.frame2.server.core.support.entity.BaseEntity;
+import com.frame2.server.core.support.exception.DomainException;
+import com.frame2.server.core.support.exception.ExceptionType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -16,4 +18,16 @@ public class Stock extends BaseEntity {
     private SaleProduct saleProduct;
 
     private int quantity;
+    
+    //재고 차감 메서드
+    public void reduceQuantity(int requestQuantity) {
+        this.quantity -= requestQuantity;
+    }
+
+    // 재고 검증 메서드
+    public void validateQuantity(int requestQuantity) {
+        if (requestQuantity > this.quantity) {
+            throw new DomainException(ExceptionType.OUT_OF_STOCK);
+        }
+    }
 }

--- a/server/src/main/java/com/frame2/server/core/support/exception/ExceptionCode.java
+++ b/server/src/main/java/com/frame2/server/core/support/exception/ExceptionCode.java
@@ -2,7 +2,12 @@ package com.frame2.server.core.support.exception;
 
 public enum ExceptionCode {
 
-    A01, A02, A03, A04, E401, A05, A06, A07, P04, C01, C02, CT04, E500,
-    O01, O02, B01, A08
-
+    E401, E500,
+    A01, A02, A03, A04, A05, A06, A07, A08,
+    B01,
+    C01, C02,
+    CT04,
+    O01, O02, O03,
+    P04,
+    S01
 }

--- a/server/src/main/java/com/frame2/server/core/support/exception/ExceptionType.java
+++ b/server/src/main/java/com/frame2/server/core/support/exception/ExceptionType.java
@@ -40,11 +40,13 @@ public enum ExceptionType {
     CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, ExceptionCode.C01, "존재하지 않는 상품입니다.", ERROR),
     EXCEEDS_MAX_ORDER_QUANTITY(ExceptionCode.C02, "최대 10개까지 주문 가능합니다."),
 
-    // -주문-
+    // - 주문 -
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, ExceptionCode.O01, "존재하지 않는 주문 내역입니다", ERROR),
-    ORDER_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, ExceptionCode.O02, "존재하지 않는 주문 상세 내역입니다.", ERROR);
+    ORDER_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, ExceptionCode.O02, "존재하지 않는 주문 상세 내역입니다.", ERROR),
+    SALE_PRODUCT_MISMATCH(HttpStatus.NOT_FOUND, ExceptionCode.O03, "요청한 판매상품 중 일부가 존재하지 않습니다", ERROR),
 
-
+    // - 재고 -
+    OUT_OF_STOCK(ExceptionCode.S01, "상품 재고가 부족합니다.");
 
     private final HttpStatus status;
 


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #36

---

### 🚀 어떤 기능을 구현했나요 ?
- [x] 주문 생성 시 재고 수량 감소 기능 구현

### 🔥 어떻게 해결했나요 ?
- [x] `Stock`엔티티에 주문 요청에 포함된 상품 재고 검증 메서드, 재고 차감 메서드 추가
  - [x] 재고보다 주문 요청 수량이 많을 시 Exception발생
- [x] 주문 생성 전 요청에 포함된 재고를 검증하고, 주문 생성
- [x] 주문이 생성된 후 주문 상세를 생성하면서 재고 수량 감소   

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말

