### PR TITLE
[BE] feat: 주문 전체 취소/부분 취소 및 재고 가산 기능 구현

### DIFF
--- a/server/src/main/java/com/frame2/server/core/order/api/OrderApi.java
+++ b/server/src/main/java/com/frame2/server/core/order/api/OrderApi.java
@@ -66,4 +66,20 @@ public class OrderApi implements OrderApiSpec{
     public List<OrderDetailResponse> getOrderDetails(@PathVariable Long orderId) {
         return orderServiceImpl.getOrderDetails(orderId);
     }
+
+    // 주문 전체 취소
+    @Override
+    //@MemberOnly
+    @PatchMapping("/{orderId}")
+    public IdResponse cancelOrder(@PathVariable Long orderId) {
+        return orderServiceImpl.cancelOrder(orderId);
+    }
+
+    // 주문 부분 취소
+    @Override
+    //@MemberOnly
+    @PatchMapping("/details/{orderDetailId}")
+    public IdResponse cancelOrderDetail(@PathVariable Long orderDetailId) {
+        return orderServiceImpl.cancelOrderDetail(orderDetailId);
+    }
 }

--- a/server/src/main/java/com/frame2/server/core/order/api/OrderApi.java
+++ b/server/src/main/java/com/frame2/server/core/order/api/OrderApi.java
@@ -22,14 +22,14 @@ import java.util.List;
 @RequestMapping("/orders")
 public class OrderApi implements OrderApiSpec{
 
-    private final OrderService orderServiceImpl;
+    private final OrderService orderService;
     
     // 주문 생성
     @Override
     @MemberOnly
     @PostMapping
     public IdResponse createOrder(@RequestBody @Valid OrderCreateRequest request) {
-        return orderServiceImpl.createOrder(request);
+        return orderService.createOrder(request);
     }
     
     // 주문 단건 조회
@@ -37,7 +37,7 @@ public class OrderApi implements OrderApiSpec{
     @MemberOnly
     @GetMapping("/{orderId}")
     public OrderResponse getOrder(@PathVariable Long orderId) {
-        return orderServiceImpl.getOrder(orderId);
+        return orderService.getOrder(orderId);
     }
     
     // 주문 전체 조회
@@ -48,7 +48,7 @@ public class OrderApi implements OrderApiSpec{
                                                @RequestParam(name = "page", defaultValue = "1") int page,
                                                @RequestParam(name = "size", defaultValue = "15") int pageSize) {
         Pageable pageable = PageRequest.of(page - 1, pageSize, Sort.by(Sort.Direction.DESC, "id"));
-        return orderServiceImpl.getOrders(memberId, pageable);
+        return orderService.getOrders(memberId, pageable);
     }
     
     // 주문 상세 단건 조회
@@ -56,7 +56,7 @@ public class OrderApi implements OrderApiSpec{
     @MemberOnly
     @GetMapping("/details/{orderDetailId}")
     public OrderDetailResponse getOderDetail(@PathVariable Long orderDetailId){
-        return orderServiceImpl.getOderDetail(orderDetailId);
+        return orderService.getOderDetail(orderDetailId);
     }
     
     // 주문 상세 전체 조회
@@ -64,7 +64,7 @@ public class OrderApi implements OrderApiSpec{
     @MemberOnly
     @GetMapping("/{orderId}/details")
     public List<OrderDetailResponse> getOrderDetails(@PathVariable Long orderId) {
-        return orderServiceImpl.getOrderDetails(orderId);
+        return orderService.getOrderDetails(orderId);
     }
 
     // 주문 전체 취소
@@ -72,7 +72,7 @@ public class OrderApi implements OrderApiSpec{
     @MemberOnly
     @PatchMapping("/{orderId}")
     public IdResponse cancelOrder(@PathVariable Long orderId) {
-        return orderServiceImpl.cancelOrder(orderId);
+        return orderService.cancelOrder(orderId);
     }
 
     // 주문 부분 취소
@@ -80,6 +80,6 @@ public class OrderApi implements OrderApiSpec{
     @MemberOnly
     @PatchMapping("/details/{orderDetailId}")
     public IdResponse cancelOrderDetail(@PathVariable Long orderDetailId) {
-        return orderServiceImpl.cancelOrderDetail(orderDetailId);
+        return orderService.cancelOrderDetail(orderDetailId);
     }
 }

--- a/server/src/main/java/com/frame2/server/core/order/api/OrderApi.java
+++ b/server/src/main/java/com/frame2/server/core/order/api/OrderApi.java
@@ -69,7 +69,7 @@ public class OrderApi implements OrderApiSpec{
 
     // 주문 전체 취소
     @Override
-    //@MemberOnly
+    @MemberOnly
     @PatchMapping("/{orderId}")
     public IdResponse cancelOrder(@PathVariable Long orderId) {
         return orderServiceImpl.cancelOrder(orderId);
@@ -77,7 +77,7 @@ public class OrderApi implements OrderApiSpec{
 
     // 주문 부분 취소
     @Override
-    //@MemberOnly
+    @MemberOnly
     @PatchMapping("/details/{orderDetailId}")
     public IdResponse cancelOrderDetail(@PathVariable Long orderDetailId) {
         return orderServiceImpl.cancelOrderDetail(orderDetailId);

--- a/server/src/main/java/com/frame2/server/core/order/api/OrderApiSpec.java
+++ b/server/src/main/java/com/frame2/server/core/order/api/OrderApiSpec.java
@@ -17,4 +17,6 @@ public interface OrderApiSpec {
     public PagedModel<OrderResponse> getOrders(Long memberId, int page, int pageSize);
     public OrderDetailResponse getOderDetail(Long orderDetailId);
     public List<OrderDetailResponse> getOrderDetails(Long orderId);
+    public IdResponse cancelOrder(Long orderId);
+    public IdResponse cancelOrderDetail(Long orderDetailId);
 }

--- a/server/src/main/java/com/frame2/server/core/order/application/OrderService.java
+++ b/server/src/main/java/com/frame2/server/core/order/application/OrderService.java
@@ -16,4 +16,6 @@ public interface OrderService {
     public PagedModel<OrderResponse> getOrders(Long memberId, Pageable pageable);
     public OrderDetailResponse getOderDetail(Long orderDetailId);
     public List<OrderDetailResponse> getOrderDetails(Long orderId);
+    public IdResponse cancelOrder(Long orderId);
+    public IdResponse cancelOrderDetail(Long orderDetailId);
 }

--- a/server/src/main/java/com/frame2/server/core/order/application/OrderServiceImpl.java
+++ b/server/src/main/java/com/frame2/server/core/order/application/OrderServiceImpl.java
@@ -115,7 +115,7 @@ public class OrderServiceImpl implements OrderService {
     @Override
     public IdResponse cancelOrder(Long orderId) {
         Order order = orderRepository.findOne(orderId);
-        order.cancelOrder(order);
+        order.cancelOrder();
         return new IdResponse(order.getId());
     }
 
@@ -125,8 +125,7 @@ public class OrderServiceImpl implements OrderService {
     @Override
     public IdResponse cancelOrderDetail(Long orderDetailId) {
         OrderDetail orderDetail = orderDetailRepository.findOne(orderDetailId);
-        orderDetail.cancelOrderDetail(orderDetail);
+        orderDetail.cancelOrderDetail();
         return new IdResponse(orderDetail.getId());
     }
-
 }

--- a/server/src/main/java/com/frame2/server/core/order/application/OrderServiceImpl.java
+++ b/server/src/main/java/com/frame2/server/core/order/application/OrderServiceImpl.java
@@ -110,20 +110,22 @@ public class OrderServiceImpl implements OrderService {
     }
     
     // 주문 전체 취소 - 주문id로 전체 취소
+        // 주문이 취소되면 모든 주문 상세도 취소
+        // 주문 상세에 포함된 상품 재고를 주문 수량만큼 가산
     @Override
     public IdResponse cancelOrder(Long orderId) {
         Order order = orderRepository.findOne(orderId);
-        order.cancelOrder();
+        order.cancelOrder(order);
         return new IdResponse(order.getId());
     }
 
     // 주문 부분 취소 - 주문 상세id로 취소
-        // 주문 상세 취소
-        // 주문 상태 변경(ORDER_PARTICAL_CANCELED)
+        // 주문 상세 취소 -> 주문 상태 변경(ORDER_PARTICAL_CANCELED)
+        // 주문 상세에 포함된 상품 재고를 주문 수량만큼 가산
     @Override
     public IdResponse cancelOrderDetail(Long orderDetailId) {
         OrderDetail orderDetail = orderDetailRepository.findOne(orderDetailId);
-        orderDetail.cancelOrderDetail();
+        orderDetail.cancelOrderDetail(orderDetail);
         return new IdResponse(orderDetail.getId());
     }
 

--- a/server/src/main/java/com/frame2/server/core/order/application/OrderServiceImpl.java
+++ b/server/src/main/java/com/frame2/server/core/order/application/OrderServiceImpl.java
@@ -108,4 +108,23 @@ public class OrderServiceImpl implements OrderService {
                 .map(OrderDetailResponse::from)
                 .toList();
     }
+    
+    // 주문 전체 취소 - 주문id로 전체 취소
+    @Override
+    public IdResponse cancelOrder(Long orderId) {
+        Order order = orderRepository.findOne(orderId);
+        order.cancelOrder();
+        return new IdResponse(order.getId());
+    }
+
+    // 주문 부분 취소 - 주문 상세id로 취소
+        // 주문 상세 취소
+        // 주문 상태 변경(ORDER_PARTICAL_CANCELED)
+    @Override
+    public IdResponse cancelOrderDetail(Long orderDetailId) {
+        OrderDetail orderDetail = orderDetailRepository.findOne(orderDetailId);
+        orderDetail.cancelOrderDetail();
+        return new IdResponse(orderDetail.getId());
+    }
+
 }

--- a/server/src/main/java/com/frame2/server/core/order/application/OrderServiceImpl.java
+++ b/server/src/main/java/com/frame2/server/core/order/application/OrderServiceImpl.java
@@ -132,4 +132,5 @@ public class OrderServiceImpl implements OrderService {
         orderDetail.cancelOrderDetail();
         return new IdResponse(orderDetail.getId());
     }
+
 }

--- a/server/src/main/java/com/frame2/server/core/order/domain/Order.java
+++ b/server/src/main/java/com/frame2/server/core/order/domain/Order.java
@@ -92,7 +92,6 @@ public class Order extends BaseEntity {
         // 재고 복원, 주문 상태 변경
     public void cancelOrder() {
         orderDetails.forEach(OrderDetail::cancelOrderDetail);
-        this.updateOrderStatus();
     }
 
     // 주문 상태 변경 메서드

--- a/server/src/main/java/com/frame2/server/core/order/domain/Order.java
+++ b/server/src/main/java/com/frame2/server/core/order/domain/Order.java
@@ -84,4 +84,16 @@ public class Order extends BaseEntity {
                 .sum();
         this.totalPrice = totalPrice;
     }
+    
+    // 주문이 취소되면 모든 주문 상세가 취소되고, 주문 상태 변경
+    public void cancelOrder() {
+        this.delete();
+        orderDetails.stream().forEach(OrderDetail::delete);
+        this.orderStatus = OrderStatus.ORDER_CANCELED;
+    }
+
+    // 주문 상태 변경 메서드
+    public void updateOrderStatus(OrderStatus orderStatus) {
+        this.orderStatus = orderStatus;
+    }
 }

--- a/server/src/main/java/com/frame2/server/core/order/domain/Order.java
+++ b/server/src/main/java/com/frame2/server/core/order/domain/Order.java
@@ -91,10 +91,8 @@ public class Order extends BaseEntity {
         // 주문은 주문 상세에게 삭제 명령만 내리도록 수정
         // 재고 복원, 주문 상태 변경
     public void cancelOrder() {
-        orderDetails.stream().forEach(orderDetail -> {
-            orderDetail.cancelOrderDetail();
-        });
-        updateOrderStatus();
+        orderDetails.forEach(OrderDetail::cancelOrderDetail);
+        this.updateOrderStatus();
     }
 
     // 주문 상태 변경 메서드

--- a/server/src/main/java/com/frame2/server/core/order/domain/OrderDetail.java
+++ b/server/src/main/java/com/frame2/server/core/order/domain/OrderDetail.java
@@ -57,7 +57,18 @@ public class OrderDetail extends BaseEntity{
         this.quantity = quantity;
         this.price = price;
         this.deliveryStatus = DeliveryStatus.PACKAGING;
-        this.exchaneReturnRequested = false;
         this.exchangeReturnPossible = true;
+        this.exchaneReturnRequested = false;
+    }
+
+    // 주문 상세가 취소되면
+        // 교환, 반품 신청 가능여부는 false로 변경
+        // 교환, 반품 신청 여부는 true로 변경
+        // 주문(Order) 상태 변경 - 주문 부분 취소
+    public void cancelOrderDetail() {
+        this.delete();
+        this.exchangeReturnPossible = false;
+        this.exchaneReturnRequested = true;
+        this.order.updateOrderStatus(OrderStatus.ORDER_PARTICAL_CANCELED);
     }
 }

--- a/server/src/main/java/com/frame2/server/core/order/domain/OrderDetail.java
+++ b/server/src/main/java/com/frame2/server/core/order/domain/OrderDetail.java
@@ -1,6 +1,7 @@
 package com.frame2.server.core.order.domain;
 
 import com.frame2.server.core.product.domain.SaleProduct;
+import com.frame2.server.core.product.domain.Stock;
 import com.frame2.server.core.support.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -61,14 +62,15 @@ public class OrderDetail extends BaseEntity{
         this.exchaneReturnRequested = false;
     }
 
-    // 주문 상세가 취소되면
-        // 교환, 반품 신청 가능여부는 false로 변경
-        // 교환, 반품 신청 여부는 true로 변경
-        // 주문(Order) 상태 변경 - 주문 부분 취소
-    public void cancelOrderDetail() {
-        this.delete();
-        this.exchangeReturnPossible = false;
-        this.exchaneReturnRequested = true;
-        this.order.updateOrderStatus(OrderStatus.ORDER_PARTICAL_CANCELED);
+    // 주문 상세가 취소 -> 주문 상세 필드 변경, 재고 복원, 주문 상태 변경
+    public void cancelOrderDetail(OrderDetail orderDetail) {
+        orderDetail.delete();
+        orderDetail.exchangeReturnPossible = false;
+        orderDetail.exchaneReturnRequested = true;
+
+        Stock stock = orderDetail.getSaleProduct().getStock();
+        stock.restoreQuantity(orderDetail.getQuantity());
+
+        orderDetail.getOrder().updateOrderStatus(OrderStatus.ORDER_PARTICAL_CANCELED);
     }
 }

--- a/server/src/main/java/com/frame2/server/core/order/domain/OrderDetail.java
+++ b/server/src/main/java/com/frame2/server/core/order/domain/OrderDetail.java
@@ -72,8 +72,10 @@ public class OrderDetail extends BaseEntity{
             this.delete();
             this.exchangeReturnPossible = false;
             this.exchaneReturnRequested = true;
+
             Stock stock = this.saleProduct.getStock();
             stock.restoreQuantity(quantity);
+
             this.order.updateOrderStatus();
         }
     }

--- a/server/src/main/java/com/frame2/server/core/order/domain/OrderDetail.java
+++ b/server/src/main/java/com/frame2/server/core/order/domain/OrderDetail.java
@@ -4,6 +4,7 @@ import com.frame2.server.core.product.domain.SaleProduct;
 import com.frame2.server.core.product.domain.Stock;
 import com.frame2.server.core.support.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,8 +14,8 @@ import java.time.LocalDate;
 
 @Entity
 @Getter
-@NoArgsConstructor
 @Table(name = "order_details")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderDetail extends BaseEntity{
     
     // 주문 id
@@ -62,15 +63,18 @@ public class OrderDetail extends BaseEntity{
         this.exchaneReturnRequested = false;
     }
 
-    // 주문 상세가 취소 -> 주문 상세 필드 변경, 재고 복원, 주문 상태 변경
-    public void cancelOrderDetail(OrderDetail orderDetail) {
-        orderDetail.delete();
-        orderDetail.exchangeReturnPossible = false;
-        orderDetail.exchaneReturnRequested = true;
-
-        Stock stock = orderDetail.getSaleProduct().getStock();
-        stock.restoreQuantity(orderDetail.getQuantity());
-
-        orderDetail.getOrder().updateOrderStatus(OrderStatus.ORDER_PARTICAL_CANCELED);
+    // 주문 상세가 취소
+        // 주문 상세 필드 변경
+        // 재고 복원
+        // 주문 상세 상태 변경
+    public void cancelOrderDetail() {
+        if(!isDeleteStatus()){
+            this.delete();
+            this.exchangeReturnPossible = false;
+            this.exchaneReturnRequested = true;
+            Stock stock = this.saleProduct.getStock();
+            stock.restoreQuantity(quantity);
+            this.order.updateOrderStatus();
+        }
     }
 }

--- a/server/src/main/java/com/frame2/server/core/order/domain/OrderStatus.java
+++ b/server/src/main/java/com/frame2/server/core/order/domain/OrderStatus.java
@@ -2,8 +2,9 @@ package com.frame2.server.core.order.domain;
 
 public enum OrderStatus {
 
-    ORDER_RECEIVED,         // 주문접수
-    ORDER_COMPLETED,        // 주문완료
-    ORDER_CANCELED,         // 주문취소
-    PURCHASED_CONFIRMED;    // 구매확정
+    ORDER_RECEIVED,             // 주문 접수
+    ORDER_COMPLETED,            // 주문 완료
+    ORDER_CANCELED,             // 주문 취소
+    ORDER_PARTICAL_CANCELED,    // 주문 일부 취소
+    PURCHASED_CONFIRMED;        // 구매 확정
 }

--- a/server/src/main/java/com/frame2/server/core/order/domain/OrderStatus.java
+++ b/server/src/main/java/com/frame2/server/core/order/domain/OrderStatus.java
@@ -7,4 +7,5 @@ public enum OrderStatus {
     ORDER_CANCELED,             // 주문 취소
     ORDER_PARTICAL_CANCELED,    // 주문 일부 취소
     PURCHASED_CONFIRMED;        // 구매 확정
+
 }

--- a/server/src/main/java/com/frame2/server/core/order/infrastructure/OrderDetailRepository.java
+++ b/server/src/main/java/com/frame2/server/core/order/infrastructure/OrderDetailRepository.java
@@ -19,4 +19,12 @@ public interface OrderDetailRepository extends JpaRepository<OrderDetail, Long> 
 
     @Query("SELECT od FROM OrderDetail od WHERE od.order.id = :orderId")
     List<OrderDetail> findAllByOrderId(@Param("orderId") Long orderId);
+
+    @Query("SELECT od " +
+            "FROM OrderDetail od " +
+            "JOIN FETCH od.order o " +
+            "JOIN FETCH od.saleProduct sp " +
+            "JOIN FETCH sp.stock s " +
+            "WHERE od.id = :orderDetailId")
+    OrderDetail findWithOrderAndSaleProduct(@Param("orderDetailId") Long orderDetailId);
 }

--- a/server/src/main/java/com/frame2/server/core/order/infrastructure/OrderRepository.java
+++ b/server/src/main/java/com/frame2/server/core/order/infrastructure/OrderRepository.java
@@ -6,8 +6,9 @@ import com.frame2.server.core.support.exception.ExceptionType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long> {
@@ -17,4 +18,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     }
 
     Page<Order> findAllByMemberId(Long memberId, Pageable pageable);
+
+    @Query("SELECT DISTINCT o FROM Order o JOIN FETCH o.orderDetails WHERE o.id = :orderId")
+    Order findWithOrderDetails(@Param("orderId") Long orderId);
 }

--- a/server/src/main/java/com/frame2/server/core/product/domain/Stock.java
+++ b/server/src/main/java/com/frame2/server/core/product/domain/Stock.java
@@ -30,4 +30,9 @@ public class Stock extends BaseEntity {
         // 재고 차감
         this.quantity -= requestQuantity;
     }
+
+    // 재고 가산 메서드
+    public void restoreQuantity(int requestQuantity) {
+        this.quantity += requestQuantity;
+    }
 }


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #84 

---

### 🚀 어떤 기능을 구현했나요 ?
- [x] 주문 전체 취소 기능 구현
  - [x] 주문이 취소되면 주문에 포함된 모든 주문 상세가 취소되어야 합니다.
  - [x] 주문 엔티티와 주문 상세 엔티티에 주문이 취소된 상태를 의미하는 모든 필드를 변경합니다.
  - [x] 최종적으로 주문의 상태는 주문이 취소되었음을 표현해야 합니다.

- [x] 주문 부분 취소 기능 구현
  - [x] 주문에 포함된 주문 상세가 취소되어도 주문은 취소되지 않아야 합니다.
  - [x] 주문 상세 엔티티에 주문 상세가 취소된 상태를 의미하는 모든 필드르 변경합니다.
  - [x] 주문은 포함된 주문 상세가 일부 취소되었으므로 주문 중 일부 취소되었음을 표현해야 합니다.

- [x] 주문 전체 취소/부분 취소에 따른 재고 가산 기능 구현
  - [x] 주문이 취소되면 주문에 포함된 상품의 재고를 주문한 수량만큼 다시 가산합니다. 

### 🔥 어떻게 해결했나요 ?
### 01.
- 주문이 취소되면 주문에 포함된 주문 상세들이 모두 취소되고, 최종적으로 주문 상태를 `ORDER_CANCELED`(주문 취소)로 변경
- 주문 상세가 취소되면, 해당 주문 상세를 취소하고 주문 상태를 `ORDER_PARTICAL_CANCELED`(주문 부분 취소)로 변경
### 💥 Issue
- 주문에 포함된 주문 상세가 일부 취소된다면 주문 상태를 `ORDER_PARTICAL_CANCELED`로 변경하고
모두 취소된다면 주문 상태를 `ORDER_CANCELED`로 변경하는 과정에서,
`orderDetailId`로 주문 상세 단건을 취소하더라도 주문 상세는 주문의 상태 변경 메서드를 호출
- 주문의 상태 변경 메서드는 주문에 포함된 모든 주문 상세를 순회하면서 취소 여부를 확인하고, 상태를 변경하는 로직으로 인해 불필요한 쿼리가 나가게 되는 문제 발생

### ✅ Solution
- `FETCH JOIN`을 활용해 필요한 연관 데이터를 한번에 조회

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- `주문 취소`라는 행위는 비지니스적이지만, 실제로 코드를 구현하다보니
엔티티의 필드를 변경하는 로직으로 이루어져 있습니다.
따라서 주문 취소와 관련된 기능들은 서비스 레이어가 아닌 주로 엔티티 내의 메서드로 동작하기 때문에,
약간의 혼란스러움과 의구심이 듭니다!
이 부분에 대해서 다양한 의견 남겨주세요!!👀

### 📚 참고 자료, 할 말
- `Order`엔티티, `OrderDetail`엔티티에서 사용하는 `delete()` 메서드는 `BaseEntity`에 정의된 메서드로,
`deleteStatus` 필드 상태를 변경하는 메서드 입니다.


📂 BaseEntity

```java

@Column(name = "delete_status", nullable = false)
private boolean deleteStatus;

public void delete() {
        this.deleteStatus = true;
}

```
