### PR TITLE
[BE] feat: 주문 기능에 @Auth, User 추가

### DIFF
--- a/server/src/main/java/com/frame2/server/core/board/application/ProductReviewServiceImpl.java
+++ b/server/src/main/java/com/frame2/server/core/board/application/ProductReviewServiceImpl.java
@@ -32,7 +32,7 @@ public class ProductReviewServiceImpl implements ProductReviewService {
     public void productReviewCreate(ProductReviewRequest request, Long memberId, Long saleProductId) {
         Member member = memberRepository.findOne(memberId);
         SaleProduct saleProduct = saleProductRepository.findOne(saleProductId);
-        OrderDetail orderDetail = orderDetailRepository.findOne(request.orderDetailId());
+        OrderDetail orderDetail = orderDetailRepository.findOne(memberId, request.orderDetailId());
 
         ProductReview productReview = request.toEntity(member, saleProduct, orderDetail);
         productReviewRepository.save(productReview);

--- a/server/src/main/java/com/frame2/server/core/order/api/OrderApi.java
+++ b/server/src/main/java/com/frame2/server/core/order/api/OrderApi.java
@@ -4,6 +4,8 @@ import com.frame2.server.core.order.application.OrderService;
 import com.frame2.server.core.order.payload.request.OrderCreateRequest;
 import com.frame2.server.core.order.payload.response.OrderDetailResponse;
 import com.frame2.server.core.order.payload.response.OrderResponse;
+import com.frame2.server.core.support.annotations.Auth;
+import com.frame2.server.core.support.request.User;
 import com.frame2.server.core.support.annotations.MemberOnly;
 import com.frame2.server.core.support.response.IdResponse;
 import jakarta.validation.Valid;
@@ -28,58 +30,58 @@ public class OrderApi implements OrderApiSpec{
     @Override
     @MemberOnly
     @PostMapping
-    public IdResponse createOrder(@RequestBody @Valid OrderCreateRequest request) {
-        return orderService.createOrder(request);
+    public IdResponse createOrder(@Auth User user, @RequestBody @Valid OrderCreateRequest request) {
+        return orderService.createOrder(user.id() ,request);
     }
     
     // 주문 단건 조회
     @Override
     @MemberOnly
     @GetMapping("/{orderId}")
-    public OrderResponse getOrder(@PathVariable Long orderId) {
-        return orderService.getOrder(orderId);
+    public OrderResponse getOrder(@Auth User user, @PathVariable Long orderId) {
+        return orderService.getOrder(user.id(), orderId);
     }
     
     // 주문 전체 조회
     @Override
     @MemberOnly
-    @GetMapping("/members/{memberId}")
-    public PagedModel<OrderResponse> getOrders(@PathVariable Long memberId,
+    @GetMapping("/members")
+    public PagedModel<OrderResponse> getOrders(@Auth User user,
                                                @RequestParam(name = "page", defaultValue = "1") int page,
                                                @RequestParam(name = "size", defaultValue = "15") int pageSize) {
         Pageable pageable = PageRequest.of(page - 1, pageSize, Sort.by(Sort.Direction.DESC, "id"));
-        return orderService.getOrders(memberId, pageable);
+        return orderService.getOrders(user.id(), pageable);
     }
     
     // 주문 상세 단건 조회
     @Override
     @MemberOnly
     @GetMapping("/details/{orderDetailId}")
-    public OrderDetailResponse getOderDetail(@PathVariable Long orderDetailId){
-        return orderService.getOderDetail(orderDetailId);
+    public OrderDetailResponse getOderDetail(@Auth User user, @PathVariable Long orderDetailId){
+        return orderService.getOderDetail(user.id(), orderDetailId);
     }
     
     // 주문 상세 전체 조회
     @Override
     @MemberOnly
     @GetMapping("/{orderId}/details")
-    public List<OrderDetailResponse> getOrderDetails(@PathVariable Long orderId) {
-        return orderService.getOrderDetails(orderId);
+    public List<OrderDetailResponse> getOrderDetails(@Auth User user, @PathVariable Long orderId) {
+        return orderService.getOrderDetails(user.id(), orderId);
     }
 
     // 주문 전체 취소
     @Override
     @MemberOnly
     @PatchMapping("/{orderId}")
-    public IdResponse cancelOrder(@PathVariable Long orderId) {
-        return orderService.cancelOrder(orderId);
+    public IdResponse cancelOrder(@Auth User user, @PathVariable Long orderId) {
+        return orderService.cancelOrder(user.id(), orderId);
     }
 
     // 주문 부분 취소
     @Override
     @MemberOnly
     @PatchMapping("/details/{orderDetailId}")
-    public IdResponse cancelOrderDetail(@PathVariable Long orderDetailId) {
-        return orderService.cancelOrderDetail(orderDetailId);
+    public IdResponse cancelOrderDetail(@Auth User user, @PathVariable Long orderDetailId) {
+        return orderService.cancelOrderDetail(user.id(), orderDetailId);
     }
 }

--- a/server/src/main/java/com/frame2/server/core/order/api/OrderApiSpec.java
+++ b/server/src/main/java/com/frame2/server/core/order/api/OrderApiSpec.java
@@ -3,6 +3,7 @@ package com.frame2.server.core.order.api;
 import com.frame2.server.core.order.payload.request.OrderCreateRequest;
 import com.frame2.server.core.order.payload.response.OrderDetailResponse;
 import com.frame2.server.core.order.payload.response.OrderResponse;
+import com.frame2.server.core.support.request.User;
 import com.frame2.server.core.support.response.IdResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.web.PagedModel;
@@ -12,11 +13,11 @@ import java.util.List;
 @Tag(name = "주문 API")
 public interface OrderApiSpec {
 
-    public IdResponse createOrder(OrderCreateRequest request);
-    public OrderResponse getOrder(Long orderId);
-    public PagedModel<OrderResponse> getOrders(Long memberId, int page, int pageSize);
-    public OrderDetailResponse getOderDetail(Long orderDetailId);
-    public List<OrderDetailResponse> getOrderDetails(Long orderId);
-    public IdResponse cancelOrder(Long orderId);
-    public IdResponse cancelOrderDetail(Long orderDetailId);
+    public IdResponse createOrder(User user, OrderCreateRequest request);
+    public OrderResponse getOrder(User user, Long orderId);
+    public PagedModel<OrderResponse> getOrders(User user, int page, int pageSize);
+    public OrderDetailResponse getOderDetail(User user, Long orderDetailId);
+    public List<OrderDetailResponse> getOrderDetails(User user, Long orderId);
+    public IdResponse cancelOrder(User user, Long orderId);
+    public IdResponse cancelOrderDetail(User user, Long orderDetailId);
 }

--- a/server/src/main/java/com/frame2/server/core/order/application/OrderService.java
+++ b/server/src/main/java/com/frame2/server/core/order/application/OrderService.java
@@ -11,11 +11,11 @@ import java.util.List;
 
 public interface OrderService {
 
-    public IdResponse createOrder(OrderCreateRequest request);
-    public OrderResponse getOrder(Long orderId);
+    public IdResponse createOrder(Long memberId, OrderCreateRequest request);
+    public OrderResponse getOrder(Long memeberId, Long orderId);
     public PagedModel<OrderResponse> getOrders(Long memberId, Pageable pageable);
-    public OrderDetailResponse getOderDetail(Long orderDetailId);
-    public List<OrderDetailResponse> getOrderDetails(Long orderId);
-    public IdResponse cancelOrder(Long orderId);
-    public IdResponse cancelOrderDetail(Long orderDetailId);
+    public OrderDetailResponse getOderDetail(Long memeberId, Long orderDetailId);
+    public List<OrderDetailResponse> getOrderDetails(Long memberId, Long orderId);
+    public IdResponse cancelOrder(Long memberId, Long orderId);
+    public IdResponse cancelOrderDetail(Long memberId, Long orderDetailId);
 }

--- a/server/src/main/java/com/frame2/server/core/order/application/OrderServiceImpl.java
+++ b/server/src/main/java/com/frame2/server/core/order/application/OrderServiceImpl.java
@@ -32,9 +32,10 @@ public class OrderServiceImpl implements OrderService {
     private final OrderDetailRepository orderDetailRepository;
     private final SaleProductRepository saleProductRepository;
 
-    public IdResponse createOrder(OrderCreateRequest request) {
+
+    public IdResponse createOrder(Long memberId, OrderCreateRequest request) {
         // 주문 생성
-        Order order = request.toEntity();
+        Order order = request.toEntity(memberId);
         orderRepository.save(order);
 
         // 판매상품 id 리스트
@@ -83,8 +84,8 @@ public class OrderServiceImpl implements OrderService {
     // 주문 내역 단건 조회 - 주문id로 단건 조회
     @Override
     @Transactional(readOnly = true)
-    public OrderResponse getOrder(Long orderId) {
-        Order order = orderRepository.findOne(orderId);
+    public OrderResponse getOrder(Long memberId, Long orderId) {
+        Order order = orderRepository.findOne(memberId, orderId);
         return OrderResponse.from(order);
     }
 
@@ -99,16 +100,16 @@ public class OrderServiceImpl implements OrderService {
     // 주문 상세 내역 단건 조회 - 주문상세id로 단건 조회
     @Override
     @Transactional(readOnly = true)
-    public OrderDetailResponse getOderDetail(Long orderDetailId) {
-        OrderDetail orderDetail = orderDetailRepository.findOne(orderDetailId);
+    public OrderDetailResponse getOderDetail(Long memberId, Long orderDetailId) {
+        OrderDetail orderDetail = orderDetailRepository.findOne(memberId, orderDetailId);
         return OrderDetailResponse.from(orderDetail);
     }
 
     // 주문 상세 내역 전체조회 - 주문id로 주문 상세 내역 전체조회
     @Override
     @Transactional(readOnly = true)
-    public List<OrderDetailResponse> getOrderDetails(Long orderId) {
-        return orderDetailRepository.findAllByOrderId(orderId).stream()
+    public List<OrderDetailResponse> getOrderDetails(Long memberId, Long orderId) {
+        return orderDetailRepository.findAllByMemberIdAndOrderId(memberId, orderId).stream()
                 .map(OrderDetailResponse::from)
                 .toList();
     }
@@ -117,8 +118,8 @@ public class OrderServiceImpl implements OrderService {
         // 주문이 취소되면 모든 주문 상세도 취소
         // 주문 상세에 포함된 상품 재고를 주문 수량만큼 가산
     @Override
-    public IdResponse cancelOrder(Long orderId) {
-        Order order = orderRepository.findWithOrderDetails(orderId);
+    public IdResponse cancelOrder(Long memberId, Long orderId) {
+        Order order = orderRepository.findWithOrderDetailsByMemberId(memberId, orderId);
         order.cancelOrder();
         return new IdResponse(order.getId());
     }
@@ -127,8 +128,8 @@ public class OrderServiceImpl implements OrderService {
         // 주문 상세 취소 -> 주문 상태 변경(ORDER_PARTICAL_CANCELED)
         // 주문 상세에 포함된 상품 재고를 주문 수량만큼 가산
     @Override
-    public IdResponse cancelOrderDetail(Long orderDetailId) {
-        OrderDetail orderDetail = orderDetailRepository.findWithOrderAndSaleProduct(orderDetailId);
+    public IdResponse cancelOrderDetail(Long memberId, Long orderDetailId) {
+        OrderDetail orderDetail = orderDetailRepository.findWithOrderAndSaleProductByMemberId(memberId, orderDetailId);
         orderDetail.cancelOrderDetail();
         return new IdResponse(orderDetail.getId());
     }

--- a/server/src/main/java/com/frame2/server/core/order/infrastructure/OrderRepository.java
+++ b/server/src/main/java/com/frame2/server/core/order/infrastructure/OrderRepository.java
@@ -10,15 +10,21 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
-    default Order findOne(Long id){
-        return findById(id).orElseThrow(() -> new DomainException(ExceptionType.ORDER_NOT_FOUND));
+    default Order findOne(Long memberId, Long orderId) {
+        return findByMemberIdAndOrderId(memberId, orderId)
+                .orElseThrow(() -> new DomainException(ExceptionType.ORDER_NOT_FOUND));
     }
+
+    @Query("SELECT o FROM Order o WHERE o.memberId = :memberId AND o.id = :orderId")
+    Optional<Order> findByMemberIdAndOrderId(@Param("memberId") Long memberId, @Param("orderId") Long orderId);
 
     Page<Order> findAllByMemberId(Long memberId, Pageable pageable);
 
-    @Query("SELECT DISTINCT o FROM Order o JOIN FETCH o.orderDetails WHERE o.id = :orderId")
-    Order findWithOrderDetails(@Param("orderId") Long orderId);
+    @Query("SELECT DISTINCT o FROM Order o JOIN FETCH o.orderDetails WHERE o.memberId = :memberId AND o.id = :orderId")
+    Order findWithOrderDetailsByMemberId(@Param("memberId") Long memberId, @Param("orderId") Long orderId);
 }

--- a/server/src/main/java/com/frame2/server/core/order/payload/request/OrderCreateRequest.java
+++ b/server/src/main/java/com/frame2/server/core/order/payload/request/OrderCreateRequest.java
@@ -9,8 +9,6 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record OrderCreateRequest(
-        @NotNull
-        Long memberId,
 
         @NotBlank(message = "받는 사람 이름은 필수입니다.")
         String recipient,
@@ -38,7 +36,7 @@ public record OrderCreateRequest(
             @Min(value = 1, message = "상품 수량은 최소 1개 이상이어야 합니다.")
             int quantity
     ){ }
-    public Order toEntity(){
+    public Order toEntity(Long memberId) {
         return Order.builder()
                 .memberId(memberId)
                 .recipient(recipient)


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #113 

---

### 🚀 어떤 기능을 구현했나요 ?
- `@Auth`, `User`를 추가해 
  - 주문 생성 시 회원 아이디가 주문에 포함되도록 한다.
  - 주문 조회 시 회원은 본인의 주문 내역만 조회할 수 있다.
  - 주문 취소 쇠 회원은 본인의 주문 내역만 취소할 수 있다.

### 🔥 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말

